### PR TITLE
Reorder sections: move AboutSection before ServicesSection

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -29,8 +29,8 @@ const Index = () => {
       />
       <Navigation />
       <HeroSection />
-      <ServicesSection />
       <AboutSection />
+      <ServicesSection />
       <LabPlanningSection />
       <SaferLabsSection />
       <GasCupboardsSection />


### PR DESCRIPTION
## Purpose
Based on the conversation, the user wanted to arrange and reorganize the order of sections to determine which content should appear at the top of the page for better user experience and content hierarchy.

## Code changes
- Moved `AboutSection` component to appear before `ServicesSection` in the Index page component
- This changes the visual order of sections on the main page, with the About section now displaying higher up in the page layoutTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/30c22f130f4e4e1981262dc4b0996130/spark-lab)

👀 [Preview Link](https://30c22f130f4e4e1981262dc4b0996130-spark-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>30c22f130f4e4e1981262dc4b0996130</projectId>-->
<!--<branchName>spark-lab</branchName>-->